### PR TITLE
Adds charm publish github action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: Publish Charm
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  publish-charm:
+    if: github.event.pull_request.merged == true
+    name: Publish Charm to edge
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libraries
+        uses: canonical/charming-actions/check-libraries@1.0.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Upload charm to charmhub
+        # TODO: update the upload-charm step once the following PR merges:
+        # https://github.com/canonical/charming-actions/pull/33
+        uses: sanchezfdezjavier/charming-actions/upload-charm@fix-upload-image-false
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          upload-image: "false"
+          channel: "edge"


### PR DESCRIPTION
After a PR merges, a new charm revision will be published on charmhub.io.

This job requires a CHARMCRAFT_AUTH secret to be added to the project with the permissions: package-manage, package-view-revisions.

Ref: https://github.com/canonical/charming-actions#usage